### PR TITLE
Add one sample z tests

### DIFF
--- a/ComStats/comstats.py
+++ b/ComStats/comstats.py
@@ -71,3 +71,13 @@ def percentage_t_test(v, weights=None, opts={'distribution': 't'}, one_sided=Fal
         p_values = stats.t.sf(np.abs(score), dof)
     p_values *= (1 if one_sided else 2)
     return p_values, score
+
+def one_sample_z_test(v, population_proportion, tails=2):
+    return one_sample_z_test_simple(v.sum(axis=1), v.shape[1], population_proportion, tails)
+
+def one_sample_z_test_simple(count, sample_size, population_proportion, tails=2):
+    ratios = count/sample_size
+    standard_error = (population_proportion * (1.0 - population_proportion) / sample_size) ** 0.5
+    score = (ratios - population_proportion) / standard_error
+    p_values = (1.0 - stats.norm.cdf(np.abs(score))) * tails
+    return p_values, score

--- a/ComStats/comstats.py
+++ b/ComStats/comstats.py
@@ -76,7 +76,7 @@ def one_sample_z_test(v, population_proportion, tails=2):
     return one_sample_z_test_simple(v.sum(axis=1), v.shape[1], population_proportion, tails)
 
 def one_sample_z_test_simple(count, sample_size, population_proportion, tails=2):
-    ratios = count/sample_size
+    ratios = count / sample_size
     standard_error = (population_proportion * (1.0 - population_proportion) / sample_size) ** 0.5
     score = (ratios - population_proportion) / standard_error
     p_values = (1.0 - stats.norm.cdf(np.abs(score))) * tails

--- a/test/test_stats.py
+++ b/test/test_stats.py
@@ -29,6 +29,21 @@ class TestComStats(unittest.TestCase):
             [1, 0.1, 0.2, 0.3, 2, 0.1, 0.1, 2, 0.1, 0.1, 0.2, 0.1, 0.3, 0.4, 1],
             [1, 0.1, 0.2, 0.3, 2, 0.1, 0.1, 2, 0.1, 0.1, 0.2, 0.1, 0.3, 0.4, 1]
         ])
+        self.sample_sizes_set = np.array([
+            [20, 50, 10, 12, 25]
+        ])
+        self.count_set = np.array([
+            [11, 20, 8, 3, 18]
+        ])
+        self.population_proportion_set = np.array([
+            [0.5, 0.3, 0.7, 0.4, 0.6]
+        ])
+        self.binary_sample_input_set = np.array([
+            [1, 0, 1, 1, 1, 0, 0, 1, 0, 1],
+            [1, 1, 1, 1, 0, 1, 1, 1, 0, 1]
+        ])
+        self.population_proportion_scalar = 0.7
+
 
     def test_unweighted_t_test(self):
         expected_p_values = [[ 1.        ,  0.00353093,  1.        ,  0.00961514],
@@ -176,5 +191,19 @@ class TestComStats(unittest.TestCase):
         expected_scores = [[ 0.        , -0.15184861],
                            [ 0.15184861,  0.        ]]
         p_values, scores = comstats.percentage_t_test(self.percentage_input_set, self.percentage_weights, {'distribution': 'z'}, True)
+        self.assertTrue((p_values.round(8) == expected_p_values).all())
+        self.assertTrue((scores.round(8) == expected_scores).all())
+
+    def test_one_sample_z_test_simple(self):
+        expected_p_values = [0.65472085, 0.12282265, 0.49015296, 0.28884437, 0.22067136]
+        expected_scores = [0.4472136, 1.5430335, 0.69006556, -1.06066017, 1.22474487]
+        p_values, scores = comstats.one_sample_z_test_simple(self.count_set, self.sample_sizes_set, self.population_proportion_set)
+        self.assertTrue((p_values.round(8) == expected_p_values).all())
+        self.assertTrue((scores.round(8) == expected_scores).all())
+
+    def test_one_sample_z_test(self):
+        expected_p_values = [0.49015296, 0.49015296]
+        expected_scores = [-0.69006556, 0.69006556]
+        p_values, scores = comstats.one_sample_z_test(self.binary_sample_input_set, self.population_proportion_scalar)
         self.assertTrue((p_values.round(8) == expected_p_values).all())
         self.assertTrue((scores.round(8) == expected_scores).all())


### PR DESCRIPTION
Adds one-sample z-tests to comstats, to be used by AutoCharts. The two functions accept params in the following formats:

**one_sample_z_test**: 
`v` -> array of arrays with equal lengths. Values are 1 (present in the sample) or 0 (not present)
`population_proportion` -> scalar, the mean population proportion

**one_sample_z_test_simple**
`count` -> array of present member counts within a sample
`sample_size` -> array of sample sizes
`population_proportion` -> array of population proportions

All of the arrays for the **one_sample_z_test_simple** params should be of equal length