### PR TITLE
Correct Weighted T Test

### DIFF
--- a/ComStats/comstats.py
+++ b/ComStats/comstats.py
@@ -16,7 +16,7 @@ def weighted_t_test_(v, weights):
     mean = np.nansum(v * weights, axis=1) / np.nansum(weights, axis=1)
     t_nom = mean[:, np.newaxis] - mean
     var = np.sqrt(np.nansum(((v.T - mean)**2) * weights.T, axis=0) / np.nansum(weights, axis=1))**2
-    t_denom = weighted_count * var + weighted_count[:, np.newaxis] * var[:, np.newaxis]
+    t_denom = (weighted_count - 1) * var + (weighted_count[:, np.newaxis] - 1) * var[:, np.newaxis]
     inv_base = 1/weighted_count + 1/weighted_count[:, np.newaxis]
     dof = weighted_count + weighted_count[:, np.newaxis] - 2
     score = t_nom / np.sqrt((t_denom * inv_base) / dof)

--- a/ComStats/comstats.py
+++ b/ComStats/comstats.py
@@ -12,14 +12,13 @@ def t_test(v, weights=None, opts={'paired': False, 'equal_variance': False}, one
     return p_values, score
 
 def weighted_t_test_(v, weights):
-    base = np.nansum(~np.isnan(v)*1, axis=1)
     weighted_count = np.nansum(weights, axis=1)
     mean = np.nansum(v * weights, axis=1) / np.nansum(weights, axis=1)
     t_nom = mean[:, np.newaxis] - mean
     var = np.sqrt(np.nansum(((v.T - mean)**2) * weights.T, axis=0) / np.nansum(weights, axis=1))**2
     t_denom = weighted_count * var + weighted_count[:, np.newaxis] * var[:, np.newaxis]
     inv_base = 1/weighted_count + 1/weighted_count[:, np.newaxis]
-    dof = base + base[:, np.newaxis] - 2
+    dof = weighted_count + weighted_count[:, np.newaxis] - 2
     score = t_nom / np.sqrt((t_denom * inv_base) / dof)
     return score, dof
 


### PR DESCRIPTION
## Summary

The weighted T-Test should be making use of the weighted base size / count when determining the T-scores as well as the P values.

This makes this correction.

## JIRA Ticket
https://zigroup.atlassian.net/browse/TA-615

## Related Pull Requests
https://github.com/Intellection/reports/pull/13250

